### PR TITLE
accept constructor parameters as a hashref

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+- accept constructor parameters as a hashref
+
 0.16    2014-10-14
 - add return_connect_error param to ->new for if you don't want ->connect to die
   (patch from Petya Kohts)

--- a/lib/Net/Graphite.pm
+++ b/lib/Net/Graphite.pm
@@ -12,6 +12,7 @@ our $TEST = 0;   # if true, don't send anything to graphite
 
 sub new {
     my $class = shift;
+    my %args = @_ == 1 && ref $_[0] eq 'HASH' ? %{$_[0]} : @_;
     return bless {
         host                 => '127.0.0.1',
         port                 => 2003,
@@ -21,7 +22,7 @@ sub new {
         timeout              => 1,
         # path
         # transformer
-        @_,
+        %args,
         # _socket
     }, $class;
 }

--- a/t/100_new.t
+++ b/t/100_new.t
@@ -20,11 +20,11 @@ $Net::Graphite::TEST = 1;
 }
 
 {
-    my $graphite = Net::Graphite->new(
+    my $graphite = Net::Graphite->new({
         host => '127.0.0.2',
         port => 2004,
         path => 'foo.bar.baz',
-    );
+    });
 
     is($graphite->{host}, '127.0.0.2', 'host set');
     is($graphite->{port}, 2004, 'port set');


### PR DESCRIPTION
It's common to accept them both as a list and a hashref, see e.g. Moose (and Moo etc.)

CatalystX::ComponentsFromConfig::ModelPlugin can only pass arguments as a hashref, so this makes Net::Graphite usable with it.
