### PR TITLE
make close() method a no-op if the _socket attribute is undef

### DIFF
--- a/lib/Net/Graphite.pm
+++ b/lib/Net/Graphite.pm
@@ -162,9 +162,8 @@ sub connect {
 # if you need to close/flush for some reason
 sub close {
     my $self = shift;
-    return unless $self->{_socket};
-    $self->{_socket}->close();
-    $self->{_socket} = undef;
+    return unless my $socket = delete $self->{_socket};
+    $socket->close();
 }
 
 sub debug {

--- a/lib/Net/Graphite.pm
+++ b/lib/Net/Graphite.pm
@@ -162,6 +162,7 @@ sub connect {
 # if you need to close/flush for some reason
 sub close {
     my $self = shift;
+    return unless $self->{_socket};
     $self->{_socket}->close();
     $self->{_socket} = undef;
 }


### PR DESCRIPTION
Just in case somebody is using the close method(), but calls it without having sent any actual metrics, this fixes the resulting exception:

Can't call method "close" on an undefined value at $PERLDIR/site/lib/Net/Graphite.pm line 153.