### PR TITLE
Trigger an error on a failed attempt of sending data if 'fire_and_for…

### DIFF
--- a/lib/Net/Graphite.pm
+++ b/lib/Net/Graphite.pm
@@ -114,6 +114,9 @@ sub flush {
 
                     substr($buf, 0, $res, '');
                 }
+                if (length($buf) && not $self->{fire_and_forget}) {
+                    confess "Error sending data";
+                }
             }
         }
         # I didn't close the socket!


### PR DESCRIPTION
This patch should fix a possibility of skipping sending errors even if `fire_and_forget` is off.